### PR TITLE
Fix _.isObject

### DIFF
--- a/src/fe/implicit/_.js
+++ b/src/fe/implicit/_.js
@@ -39,8 +39,8 @@ export const isBoolean = isType('boolean');
 export const isNumber = isType('number');
 export const isString = isType('string');
 export const isFunction = isType('function');
-export const isObject = isType('object');
 export const isArray = Array.isArray;
+export const isObject = o => !isArray(o) && isType(o, 'object');
 export const isElement = o => isNonNullObject(o) && o.nodeType === 1;
 export const isTruthy = o => o;
 


### PR DESCRIPTION
Currently, `_.isNonNullObject([])` evaluates to `true`, because `_.isObject` checks for type, which is `object` for arrays too.