### PR TITLE
Fix _Obj.unflatten

### DIFF
--- a/src/fe/implicit/_Obj.js
+++ b/src/fe/implicit/_Obj.js
@@ -207,7 +207,7 @@ export const unflatten = o => {
 
   loop(o, (val, key) => {
     // Remove square brackets and replace them with delimiter.
-    key.replace(/\[([^[\]]+)\]/g, `${delimiter}$1`);
+    key = key.replace(/\[([^[\]]+)\]/g, `${delimiter}$1`);
 
     const keys = key.split(delimiter);
     let _r = result;

--- a/tests/fe/implicit/_Obj.js
+++ b/tests/fe/implicit/_Obj.js
@@ -271,10 +271,22 @@ describe('_Obj', () => {
   });
 
   describe('unflattens', () => {
+    it('correctly flattens an empty object', () => {
+      const obj = {};
+      const obj2 = _Obj.unflatten(obj);
+      const expected = {};
+      deepEqual(obj2, expected);
+    });
     it('Check if it correctly unflattens an object', () => {
       const obj = { 'a.b': 1 };
       const obj2 = _Obj.unflatten(obj);
       const expected = { a: { b: 1 } };
+      deepEqual(obj2, expected);
+    });
+    it('Check if it correctly unflattens an object with parenthesized subkeys', () => {
+      const obj = { 'a[b][c]': 1 };
+      const obj2 = _Obj.unflatten(obj);
+      const expected = { a: { b: { c: 1 } } };
       deepEqual(obj2, expected);
     });
   });


### PR DESCRIPTION
# Description

`_Obj.unflatten` did not work for objects with subkeys inside square brackets, e. g. for `{ 'a[b]': 1 }`. This PR fixes that.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else

# Tests

- [ ] Changes in the PR do not require changes in tests
- [ ] Existing tests needed to be updated
- [x] New tests have been added

## If tests have been added/updated

- `_Obj.js`
  - Previous coverage: 100%
  - Updated coverage: 100%

# Documentation

- [x] Documentation does not require updates
- [ ] Documentation requires updates and has been committed
