### PR TITLE
Use filter in _Arr.remove

### DIFF
--- a/src/fe/implicit/_Arr.js
+++ b/src/fe/implicit/_Arr.js
@@ -187,17 +187,9 @@ export const append = _.curry2((array, member) => {
  *
  * @returns {Array}
  */
-export const remove = _.curry2((array, member) => {
-  let memberIndex = indexOf(array, member);
-
-  if (memberIndex >= 0) {
-    return protoSlice
-      .call(array, 0, memberIndex)
-      .concat(protoSlice.call(array, memberIndex + 1));
-  } else {
-    return array;
-  }
-});
+export const remove = _.curry2((array, member) =>
+  filter(array, item => item !== member)
+);
 
 /**
  * Returns the first item of the array.


### PR DESCRIPTION
# Description

`_Arr.remove` returns the same array if the item is missing. In case the item is not missing, it returns a new array. Let's change this behavior and return a new array regardless of the existence of the item.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else

# Tests

- [x] Changes in the PR do not require changes in tests
- [ ] Existing tests needed to be updated
- [ ] New tests have been added

# Documentation

- [x] Documentation does not require updates
- [ ] Documentation requires updates and has been committed
