### PR TITLE
 Add _El.toggleCLass and _El.keepClass

### DIFF
--- a/docs/fe/implicit/_El.md
+++ b/docs/fe/implicit/_El.md
@@ -94,7 +94,7 @@ Moves caret for an element between the given positions
 - `el` **[Element][2]**
 - `position` **[number][3]**
 
-Returns **[Object][4]**
+Returns **[Element][2]**
 
 ## submit
 
@@ -104,7 +104,7 @@ Call submit method on the given element.
 
 - `el` **[Element][2]**
 
-Returns **[Object][4]**
+Returns **[Element][2]**
 
 ## hasClass
 
@@ -112,10 +112,10 @@ Checks if the given element has the given class.
 
 ### Parameters
 
-- `el` **[Object][4]**
+- `el` **[Element][2]**
 - `className` **[string][1]**
 
-Returns **[boolean][5]**
+Returns **[boolean][4]**
 
 ## addClass
 
@@ -123,10 +123,10 @@ Adds a class to the given element.
 
 ### Parameters
 
-- `el` **[Object][4]**
+- `el` **[Element][2]**
 - `className` **[string][1]**
 
-Returns **[Object][4]**
+Returns **[Element][2]**
 
 ## removeClass
 
@@ -134,10 +134,34 @@ Removes a class from the given element.
 
 ### Parameters
 
-- `el` **[Object][4]**
+- `el` **[Element][2]**
 - `className` **[string][1]**
 
-Returns **[Object][4]**
+Returns **[Element][2]**
+
+## toggleClass
+
+Removes the class if it is attached.
+Adds a class if it is not attached.
+
+### Parameters
+
+- `el` **[Element][2]**
+- `className` **[string][1]**
+
+Returns **[Element][2]**
+
+## keepClass
+
+Adds or removes class based on `keep`
+
+### Parameters
+
+- `el` **[Element][2]**
+- `className` **[string][1]**
+- `keep` **[boolean][4]**
+
+Returns **[Element][2]**
 
 ## getAttribute
 
@@ -160,7 +184,7 @@ Sets attribute of the given element.
 - `attr` **[string][1]**
 - `value` **[string][1]**
 
-Returns **[Object][4]**
+Returns **[Object][5]**
 
 ## setStyle
 
@@ -172,7 +196,7 @@ Sets style of the given element.
 - `cssProp` **[string][1]**
 - `value` **[string][1]**
 
-Returns **[Object][4]**
+Returns **[Object][5]**
 
 ## setAttributes
 
@@ -181,9 +205,9 @@ Sets multiple attibutes of the given element.
 ### Parameters
 
 - `el` **[Element][2]**
-- `attributes` **[Object][4]**
+- `attributes` **[Object][5]**
 
-Returns **[Object][4]**
+Returns **[Object][5]**
 
 ## setStyles
 
@@ -192,9 +216,9 @@ Sets multiple styles of the given element.
 ### Parameters
 
 - `el` **[Element][2]**
-- `styles` **[Object][4]**
+- `styles` **[Object][5]**
 
-Returns **[Object][4]**
+Returns **[Object][5]**
 
 ## setContents
 
@@ -205,7 +229,7 @@ Sets contents of the given element.
 - `el` **[Element][2]**
 - `html` **[string][1]**
 
-Returns **[Object][4]**
+Returns **[Object][5]**
 
 ## setDisplay
 
@@ -216,7 +240,7 @@ Sets the display style of the given element.
 - `el` **[Element][2]**
 - `value` **[string][1]**
 
-Returns **[Object][4]**
+Returns **[Object][5]**
 
 ## bbox
 
@@ -226,7 +250,7 @@ Gets the size of an element and its position relative to the viewport
 
 - `el` **[Element][2]**
 
-Returns **[Object][4]**
+Returns **[Object][5]**
 
 ## firstChild
 
@@ -236,7 +260,7 @@ Gets the first Child of the given element.
 
 - `el` **[Element][2]**
 
-Returns **[Object][4]**
+Returns **[Object][5]**
 
 ## matches
 
@@ -247,10 +271,10 @@ Checks if the given element and the selector matches.
 - `el` **[Element][2]**
 - `selector` **[string][1]**
 
-Returns **[Object][4]**
+Returns **[Object][5]**
 
 [1]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 [2]: https://developer.mozilla.org/docs/Web/API/Element
 [3]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
-[4]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
-[5]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[4]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[5]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object

--- a/src/fe/implicit/_El.js
+++ b/src/fe/implicit/_El.js
@@ -129,7 +129,7 @@ export const selectionEnd = _.prop('selectionEnd') |> element1;
  * @param {Element} el
  * @param {number} position
  *
- * @returns {Object}
+ * @returns {Element}
  */
 export const moveCaret =
   ((el, position) => {
@@ -143,7 +143,7 @@ export const moveCaret =
  * Call submit method on the given element.
  * @param {Element} el
  *
- * @returns {Object}
+ * @returns {Element}
  */
 export const submit =
   (el => {
@@ -153,7 +153,7 @@ export const submit =
 
 /**
  * Checks if the given element has the given class.
- * @param {Object} el
+ * @param {Element} el
  * @param {string} className
  *
  * @returns {boolean}
@@ -167,10 +167,10 @@ export const hasClass =
 
 /**
  * Adds a class to the given element.
- * @param {Object} el
+ * @param {Element} el
  * @param {string} className
  *
- * @returns {Object}
+ * @returns {Element}
  */
 export const addClass =
   ((el, className) => {
@@ -186,10 +186,10 @@ export const addClass =
 
 /**
  * Removes a class from the given element.
- * @param {Object} el
+ * @param {Element} el
  * @param {string} className
  *
- * @returns {Object}
+ * @returns {Element}
  */
 export const removeClass =
   ((el, className) => {

--- a/src/fe/implicit/_El.js
+++ b/src/fe/implicit/_El.js
@@ -206,6 +206,48 @@ export const removeClass =
   |> _.curry2;
 
 /**
+ * Removes the class if it is attached.
+ * Adds a class if it is not attached.
+ * @param {Element} el
+ * @param {string} className
+ *
+ * @returns {Element}
+ */
+export const toggleClass =
+  ((el, className) => {
+    if (hasClass(el, className)) {
+      removeClass(el, className);
+    } else {
+      addClass(el, className);
+    }
+
+    return el;
+  })
+  |> elementString
+  |> _.curry2;
+
+/**
+ * Adds or removes class based on `keep`
+ * @param {Element} el
+ * @param {string} className
+ * @param {boolean} keep
+ *
+ * @returns {Element}
+ */
+export const keepClass =
+  ((el, className, keep) => {
+    if (keep) {
+      addClass(el, className);
+    } else {
+      removeClass(el, className);
+    }
+
+    return el;
+  })
+  |> elementString
+  |> _.curry3;
+
+/**
  * Gets attribute of the given element.
  * @param {Element} el
  * @param {string} attr

--- a/tests/fe/implicit/_El.js
+++ b/tests/fe/implicit/_El.js
@@ -172,6 +172,55 @@ describe('_El', function() {
     });
   });
 
+  describe('toggleClass', () => {
+    it('adds class if it does not exist', () => {
+      const div = _El.create('div');
+      isFalse(_El.hasClass(div, 'test'));
+      _El.toggleClass(div, 'test');
+      isTrue(_El.hasClass(div, 'test'));
+    });
+
+    it('removes class if it exists', () => {
+      const div = _El.create('div');
+      _El.addClass(div, 'test');
+      isTrue(_El.hasClass(div, 'test'));
+      _El.toggleClass(div, 'test');
+      isFalse(_El.hasClass(div, 'test'));
+    });
+  });
+
+  describe('keepClass', () => {
+    it('when keep=true, it adds class if it was absent', () => {
+      const div = _El.create('div');
+      isFalse(_El.hasClass(div, 'test'));
+      _El.keepClass(div, 'test', true);
+      isTrue(_El.hasClass(div, 'test'));
+    });
+
+    it('when keep=true, it does not remove the class if present', () => {
+      const div = _El.create('div');
+      _El.addClass(div, 'test');
+      isTrue(_El.hasClass(div, 'test'));
+      _El.keepClass(div, 'test', true);
+      isTrue(_El.hasClass(div, 'test'));
+    });
+
+    it('when keep=false, it removes class if it was present', () => {
+      const div = _El.create('div');
+      _El.addClass(div, 'test');
+      isTrue(_El.hasClass(div, 'test'));
+      _El.keepClass(div, 'test', false);
+      isFalse(_El.hasClass(div, 'test'));
+    });
+
+    it('when keep=false, it does not add the class if absent', () => {
+      const div = _El.create('div');
+      isFalse(_El.hasClass(div, 'test'));
+      _El.keepClass(div, 'test', false);
+      isFalse(_El.hasClass(div, 'test'));
+    });
+  });
+
   describe('getAttribute', () => {
     const div = _El.create('div');
     div.setAttribute('class', 'red blue');


### PR DESCRIPTION
# Description

Adds `_El.toggleCLass` and `_El.keepClass` for class manipulation.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else

# Tests

- [ ] Changes in the PR do not require changes in tests
- [ ] Existing tests needed to be updated
- [x] New tests have been added

## If tests have been added/updated

- `_El.js`
  - Previous coverage: 81.65%
  - Updated coverage: 83.19%

# Documentation

- [ ] Documentation does not require updates
- [x] Documentation requires updates and has been committed
