### PR TITLE
[Fetch] Do not stringify FormData

### DIFF
--- a/src/fe/implicit/fetch.js
+++ b/src/fe/implicit/fetch.js
@@ -135,7 +135,7 @@ function normalizeOptions(options) {
   if (!callback) {
     options.callback = _Func.noop;
   }
-  if (_.isNonNullObject(data)) {
+  if (_.isNonNullObject(data) && !_.is(data, FormData)) {
     data = _.obj2query(data);
   }
   options.data = data;


### PR DESCRIPTION
# Description

`fetch` currently stringifies all data. It should not stringify `FormData`. This PR fixes that.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else

# Tests

- [x] Changes in the PR do not require changes in tests
- [ ] Existing tests needed to be updated
- [ ] New tests have been added

# Documentation

- [x] Documentation does not require updates
- [ ] Documentation requires updates and has been committed
