### PR TITLE
[Promise] Invoke callback and then call _then_ for finally

### DIFF
--- a/src/fe/implicit/Promise.js
+++ b/src/fe/implicit/Promise.js
@@ -138,8 +138,8 @@ Promise.prototype
 
     finally: function(callback) {
       return this.then(
-        value => Promise.resolve(callback().then(() => value)),
-        reason => Promise.resolve(callback().then(() => Promise.reject(reason)))
+        value => Promise.resolve(callback()).then(() => value),
+        reason => Promise.resolve(callback()).then(() => Promise.reject(reason))
       );
     },
   });

--- a/src/fe/implicit/Promise.js
+++ b/src/fe/implicit/Promise.js
@@ -187,4 +187,9 @@ const PromiseRuntime =
     globalPromise) ||
   Promise;
 
+// Add finally to runtime if it doesn't exist.
+if (!_.isFunction(PromiseRuntime.prototype.finally)) {
+  PromiseRuntime.prototype.finally = Promise.prototype.finally;
+}
+
 export default PromiseRuntime;


### PR DESCRIPTION
# Description

`callback` was invoked and was expected to return a Promise, which should not be the case. Other polyfills for Promise invoke the callback, and then invoke `then`.

https://github.com/taylorhakes/promise-polyfill/blob/685e18bbf96113e254d3d4d77a82f4cfc92b089e/src/finally.js#L9
https://github.com/stefanpenner/es6-promise/blob/f97e2666e6928745c450752e74213d2438b48b4c/lib/es6-promise/promise.js#L414

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else

# Tests

- [x] Changes in the PR do not require changes in tests
- [ ] Existing tests needed to be updated
- [ ] New tests have been added

# Documentation

- [x] Documentation does not require updates
- [ ] Documentation requires updates and has been committed
