### PR TITLE
Add script to fix lint issues in files and curly: 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Documentation can be found in the [docs](docs) directory.
 - `eslint` - ESLint helpers and config
 - `eslint-compat`
 - `estlinrc` - ESLint rules
+- `lintFix` - Fixes a file using ESLint and writes it to disk
 - `lintOutput` - Helpers to lint generated builds
 - `rollup-injects` - Implicit injects for rollup
 - `rollup-plugins` - Utils for rollup

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     }
   },
   "bin": {
+    "lintFix": "scripts/lintFix.js",
     "lintOutput": "scripts/lintOutput.js",
     "$": "bin/$",
     "serve": "bin/serve"

--- a/scripts/eslint.js
+++ b/scripts/eslint.js
@@ -7,6 +7,21 @@ const eslint = new CLIEngine(lintRules);
 const eslintFormatter = eslint.getFormatter('stylish');
 const lintCompat = new CLIEngine(require('./eslintrc-compat'));
 
+/**
+ * Fixes ESLint issues
+ * @param {Array<string>} paths
+ */
+const lintFix = paths => {
+  const fixer = new CLIEngine({
+    ...lintRules,
+    fix: true,
+  });
+
+  const report = fixer.executeOnFiles(paths);
+
+  CLIEngine.outputFixes(report);
+};
+
 const lintPaths = paths => {
   if (!Array.isArray(paths)) {
     if (!paths.endsWith('.js')) {
@@ -43,7 +58,8 @@ const lintText = (text, id) => lintLog(eslint.executeOnText(text, id));
 
 module.exports = {
   lint,
+  lintCompat,
+  lintFix,
   lintLog,
   lintText,
-  lintCompat,
 };

--- a/scripts/eslintrc.js
+++ b/scripts/eslintrc.js
@@ -42,7 +42,7 @@ module.exports = {
     'no-extend-native': 2, // disallow meddling with built-in object prototypes
     'no-proto': 2, // disable __proto__
     'no-prototype-builtins': 0, // Access Object.prototype method 'hasOwnProperty' from target object
-
+    curly: 2, // Require curly braces
     'linebreak-style': [2, 'unix'],
 
     // disable getters and setters

--- a/scripts/lintFix.js
+++ b/scripts/lintFix.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+const { lintFix } = require('./eslint');
+
+lintFix(process.argv.slice(2));


### PR DESCRIPTION
# Description

Adds `curly: 2` ESLint rule. Also adds a script that fixes lint issues on the files and writes them to disk.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Something else

# Tests

- [x] Changes in the PR do not require changes in tests
- [ ] Existing tests needed to be updated
- [ ] New tests have been added

# Documentation

- [x] Documentation does not require updates
- [ ] Documentation requires updates and has been committed
