### PR TITLE
Fix non-ASCII characters in identifier

### DIFF
--- a/src/fe/implicit/_Doc.js
+++ b/src/fe/implicit/_Doc.js
@@ -154,7 +154,7 @@ export function smoothScrollTo(y) {
 }
 
 var scrollTimeout;
-const π = Math.PI;
+const pi = Math.PI;
 
 /**
  * Smoothly scroll by given point
@@ -179,7 +179,7 @@ export function smoothScrollBy(y) {
       if (scrollCount >= 1) {
         return scrollTo(0, target);
       }
-      var sin = Math.sin((π * scrollCount) / 2);
+      var sin = Math.sin((pi * scrollCount) / 2);
       scrollTo(0, y0 + Math.round(y * sin));
       oldTimestamp = newTimestamp;
       requestAnimationFrame(step);


### PR DESCRIPTION
# Description

The π variable name is sometimes incorrectly transpiled which leads to a syntax error.

![Screenshot from 2020-05-06 07-01-46](https://user-images.githubusercontent.com/7722412/81131120-bb992200-8f67-11ea-937d-795d41ea4d20.png)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Tests

- [x] Changes in the PR do not require changes in tests

# Documentation

- [x] Documentation does not require updates
