### PR TITLE
Throw errors while logging

### DIFF
--- a/src/fe/implicit/_.js
+++ b/src/fe/implicit/_.js
@@ -43,13 +43,21 @@ export function validateArgs(...validators) {
     function() {
       let args = arguments;
       if (
-        validators.every(
-          (v, i) => v(args[i]) || logError(`wrong ${i}th argtype`, args[i])
-        )
+        validators.every((v, i) => {
+          const valid = v(args[i]);
+
+          if (!valid) {
+            const _error = `wrong ${i}th argtype: ${args[i]}`;
+
+            logError(_error);
+            throw _error;
+          }
+
+          return valid;
+        })
       ) {
         return func.apply(null, args);
       }
-      return args[0];
     };
 }
 

--- a/src/fe/implicit/_Func.js
+++ b/src/fe/implicit/_Func.js
@@ -90,6 +90,7 @@ export const invoke = function(func) {
     return func.apply(this, arguments |> _Arr.sliceFrom(1));
   } catch (e) {
     _.logError(e);
+    throw e;
   }
 };
 

--- a/tests/fe/implicit/_.js
+++ b/tests/fe/implicit/_.js
@@ -95,12 +95,14 @@ describe('_', () => {
       validators.object
     )(dummy);
 
-    it('validates without throwing any error', () => {
+    it('validates properly', () => {
       equal(dummyWithValidation('bar', {}), 'foo');
     });
 
-    it('returns the first arg when validation fails', () => {
-      equal(dummyWithValidation('x', 1), 'x');
+    it('throws an error when validation fails', () => {
+      throws(() => {
+        dummyWithValidation('x', 1);
+      });
     });
   });
 

--- a/tests/fe/implicit/_Func.js
+++ b/tests/fe/implicit/_Func.js
@@ -124,8 +124,9 @@ describe('_Func', () => {
       equal(said, expected);
     });
 
-    it('does not invoke in case a function is not provided', () => {
+    it('throws an error when a function is not provided', () => {
       let invoked = false;
+      let returned;
 
       function fn() {
         invoked = true;
@@ -133,7 +134,9 @@ describe('_Func', () => {
         return invoked;
       }
 
-      const returned = _Func.invoke(1);
+      throws(() => {
+        returned = _Func.invoke(1);
+      });
 
       isFalse(invoked);
       isUndefined(returned);


### PR DESCRIPTION
# Description

We are currently just logging errors if `validateArgs` fails. We should also be throwing these errors.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else

# Tests

- [ ] Changes in the PR do not require changes in tests
- [x] Existing tests needed to be updated
- [ ] New tests have been added

## If tests have been added/updated

- `_.js`
  - Previous coverage: 96.49%
  - Updated coverage: 96.61%
- `_Func.js`
  - Previous coverage: 97.92%
  - Updated coverage: 97.96%

# Documentation

- [x] Documentation does not require updates
- [ ] Documentation requires updates and has been committed
