### PR TITLE
Fix payload for JSONP

### DIFF
--- a/src/fe/implicit/fetch.js
+++ b/src/fe/implicit/fetch.js
@@ -222,15 +222,20 @@ function jsonp(options) {
 
     this.setReq('jsonp', req);
 
-    // Set the callback name in the request.
-    const payload = _Obj.extend(
-      { callback: `Razorpay.${callbackName}` },
-      options.data
+    // Make the source URL
+    let src = _.appendParamsToUrl(options.url, options.data);
+
+    // Add callback name to the source URL
+    src = _.appendParamsToUrl(
+      src,
+      _.obj2query({
+        callback: `Razorpay.${callbackName}`,
+      })
     );
 
     _El.create('script')
       |> _Obj.extend({
-        src: _.appendParamsToUrl(options.url, payload),
+        src,
         async: true,
         onerror: e => options.callback(networkError),
         onload,


### PR DESCRIPTION
# Description

Issue introduced in #366 where payload was a string and `_Obj.extend` was being done on it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else

# Tests

- [x] Changes in the PR do not require changes in tests
- [ ] Existing tests needed to be updated
- [ ] New tests have been added

## If tests have been added/updated

- `fetch.js`
  - Previous coverage: 63.25%
  - Updated coverage: 62.71%

# Documentation

- [x] Documentation does not require updates
- [ ] Documentation requires updates and has been committed
