### PR TITLE
Add retry to failed fetch.till

### DIFF
--- a/src/fe/implicit/fetch.js
+++ b/src/fe/implicit/fetch.js
@@ -53,13 +53,16 @@ _Func.setPrototype(fetch, {
     return this;
   },
 
-  till: function(continueUntilFn) {
+  till: function(continueUntilFn, retryLimit = 0) {
     return this.setReq(
       'timeout',
       setTimeout(() => {
         this.call(response => {
-          if (continueUntilFn(response)) {
-            this.till(continueUntilFn);
+          // If there is an error, retry again until retry limit.
+          if (response.error && retryLimit > 0) {
+            this.till(continueUntilFn, retryLimit - 1);
+          } else if (continueUntilFn(response)) {
+            this.till(continueUntilFn, retryLimit);
           } else {
             this.options.callback(response);
           }


### PR DESCRIPTION
# Description

Fetch.till stops polling once the request fails due to a network failure. This PR adds an additional parameter to fetch.till that specifies the no. of retries to be performed before failing itself.

## Type of change

- New feature (non-breaking change which adds functionality)

# Tests

- Changes in the PR do not require changes in tests
- Fetch.till tests aren't present, they need to be added.

## If tests have been added/updated

- `fetch.js`
  - Previous coverage: 62.71%
  - Updated coverage: 61.16%

