### PR TITLE
Do not invoke options.callback directly for JSONP script error

### DIFF
--- a/src/fe/implicit/fetch.js
+++ b/src/fe/implicit/fetch.js
@@ -240,7 +240,7 @@ function jsonp(options) {
       |> _Obj.extend({
         src,
         async: true,
-        onerror: e => options.callback(networkError),
+        onerror: e => cb(networkError),
         onload,
         onreadystatechange: onload,
       })


### PR DESCRIPTION
# Description

When script loading failed for JSONP, we were directly invoking the callback from options, which was the default value for the callback passed in `request.call` [here](https://github.com/razorpay/common-frontend-utils/blob/8392837523f9e624795eaf202ce8e0f3ec0210ea/src/fe/implicit/fetch.js#L199). This meant that actual callback passed to `request.call` would not be called for script errors, which caused JSONP with retries to fail on the first attempt. 

This PR fixes it by calling the actual callback passed to `request.call`.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Tests

- Changes in the PR do not require changes in tests

## If tests have been added/updated

- `fetch.js`
  - Previous coverage: 61.16%
  - Updated coverage: 61.16%

# Documentation

- Documentation does not require updates
