### PR TITLE
Dispatch events along with logging errors

### DIFF
--- a/src/fe/implicit/_.js
+++ b/src/fe/implicit/_.js
@@ -43,9 +43,18 @@ export function validateArgs(...validators) {
     function() {
       let args = arguments;
       if (
-        validators.every(
-          (v, i) => v(args[i]) || logError(`wrong ${i}th argtype`, args[i])
-        )
+        validators.every((v, i) => {
+          if (v(args[i])) {
+            return true;
+          } else {
+            logError(`wrong ${i}th argtype`, args[i]);
+            global.dispatchEvent(
+              CustomEvent('rzp_error', {
+                detail: new Error(`wrong ${i}th argtype ${args[i]}`),
+              })
+            );
+          }
+        })
       ) {
         return func.apply(null, args);
       }
@@ -437,3 +446,21 @@ export const getQueryParams = function(search = location.search) {
 
   return {};
 };
+
+/**
+ * Creates an IE-compatible Custom Event
+ * Source: https://stackoverflow.com/a/26596324/4176188
+ * @param {string} event
+ * @param {Object} params
+ *
+ * @returns {Event}
+ */
+export function CustomEvent(event, params) {
+  params = params || { bubbles: false, cancelable: false, detail: undefined };
+
+  const evt = document.createEvent('CustomEvent');
+
+  evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail);
+
+  return evt;
+}

--- a/src/fe/implicit/_Func.js
+++ b/src/fe/implicit/_Func.js
@@ -90,6 +90,11 @@ export const invoke = function(func) {
     return func.apply(this, arguments |> _Arr.sliceFrom(1));
   } catch (e) {
     _.logError(e);
+    global.dispatchEvent(
+      _.CustomEvent('rzp_error', {
+        detail: e,
+      })
+    );
   }
 };
 

--- a/tests/fe/implicit/_.js
+++ b/tests/fe/implicit/_.js
@@ -683,4 +683,20 @@ describe('_', () => {
       deep(params, expected);
     });
   });
+
+  describe('CustomEvent', () => {
+    it('Creates a CustomEvent', () => {
+      const event = _.CustomEvent('myevent', {
+        detail: {
+          foo: 'bar',
+        },
+      });
+
+      equal(event.type, 'myevent');
+
+      deep(event.detail, {
+        foo: 'bar',
+      });
+    });
+  });
 });


### PR DESCRIPTION
# Description

We will now dispatch an `rzp_error` event on window along with logging the error. The consumer can listen for this event and do any error-tracking it needs to.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else

# Tests

- [ ] Changes in the PR do not require changes in tests
- [ ] Existing tests needed to be updated
- [x] New tests have been added

## If tests have been added/updated

- `_.js`
  - Previous coverage: 96.49%
  - Updated coverage: 96.69%
- `_Func.js`
  - Previous coverage: 97.92%
  - Updated coverage: 97.96%

# Documentation

- [x] Documentation does not require updates
- [ ] Documentation requires updates and has been committed
