### PR TITLE
Dispatch rzp_network_error event for network errors

### DIFF
--- a/src/fe/implicit/fetch.js
+++ b/src/fe/implicit/fetch.js
@@ -113,6 +113,22 @@ _Func.setPrototype(fetch, {
             text: xhr.responseText,
           };
         }
+
+        if (json.error) {
+          global.dispatchEvent(
+            _.CustomEvent('rzp_network_error', {
+              detail: {
+                method,
+                url,
+                baseUrl: url.split('?')[0],
+                status: xhr.status,
+                xhrErrored: false,
+                response: json,
+              },
+            })
+          );
+        }
+
         callback(json);
       }
     };
@@ -121,6 +137,20 @@ _Func.setPrototype(fetch, {
       resp.xhr = {
         status: 0,
       };
+
+      global.dispatchEvent(
+        _.CustomEvent('rzp_network_error', {
+          detail: {
+            method,
+            url,
+            baseUrl: url.split('?')[0],
+            status: 0,
+            xhrErrored: true,
+            response: resp,
+          },
+        })
+      );
+
       callback(resp);
     };
 


### PR DESCRIPTION
# Description

We will not dispatch an error on window that can be used to track network errors.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else

# Tests

- [x] Changes in the PR do not require changes in tests
- [ ] Existing tests needed to be updated
- [ ] New tests have been added

## If tests have been added/updated

- `fetch.js`
  - Previous coverage: 61.16%
  - Updated coverage: 61.29%

# Documentation

- [x] Documentation does not require updates
- [ ] Documentation requires updates and has been committed
